### PR TITLE
fix: remove step summary action

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ GitHub Actions for [gha-trigger](https://gha-trigger.github.io)
 
 ## What does this action do?
 
-- Show GitHub Actions Step Summary by [gha-trigger/step-summary-action](https://github.com/gha-trigger/step-summary-action)
 - Set Environment Variables by [gha-trigger/set-env-action](https://github.com/gha-trigger/set-env-action)
 - Generate GitHub App Token by [tibdex/github-app-token](https://github.com/tibdex/github-app-token)
 - Set the commit status to `pending`

--- a/action.yaml
+++ b/action.yaml
@@ -56,9 +56,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: gha-trigger/step-summary-action@v0.1.0
-      with:
-        data: ${{inputs.data}}
     - uses: gha-trigger/set-env-action@v0.1.0
       with:
         data: ${{inputs.data}}


### PR DESCRIPTION
step-summary-action should be run once in the workflow.
So we should add a job for step-summary-action.